### PR TITLE
Disabled automatic tab-focus change

### DIFF
--- a/ExcelAddIn/Forms/UploadForm.cs
+++ b/ExcelAddIn/Forms/UploadForm.cs
@@ -712,7 +712,7 @@ namespace Avinet.Adaptive.Statistics.ExcelAddIn
                     pDataOrientation != this.StatVarProperties.DataOrientation)
                 {
                     this.LoadStatVarPropertiesGrid();
-                    tabControl.SelectedTab = tpStatisticsVariables;
+                    //tabControl.SelectedTab = tpStatisticsVariables;
                 }
 
                 // Parse with current settings


### PR DESCRIPTION
@eirikcsak
- Upon selection of the column that contains statistical variables, the focus of the tab control (tabControl) at the bottom of the upload window would automatically change to the statistical variable tab.
- This was seen as irritating if the user selected statistical variables first and then moved on to select other parameters.
- Commented out the change focus action in this PR
